### PR TITLE
Fix product card and dark mode colors

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -20,13 +20,13 @@ const ProductCard = ({ product }: ProductCardProps) => {
             className="w-full h-64 object-cover transition-transform duration-300 group-hover:scale-110"
           />
           {product.isNew && (
-            <Badge className="absolute top-3 left-3 bg-gradient-to-r from-accent to-accent/90 text-accent-foreground font-bold shadow-lg border border-accent/20 backdrop-blur-sm">
+            <Badge className="absolute top-3 left-3 bg-gradient-to-r from-accent to-accent/90 text-black dark:text-white font-bold shadow-lg border border-accent/20 backdrop-blur-sm">
               Novo
             </Badge>
           )}
           <Badge 
             variant="secondary" 
-            className="absolute top-3 right-3 bg-background/90 text-foreground font-semibold shadow-md border border-border backdrop-blur-sm hover:bg-background/95 transition-colors"
+            className="absolute top-3 right-3 bg-white/90 dark:bg-gray-800/90 text-gray-900 dark:text-gray-100 font-semibold shadow-md border border-gray-200/50 dark:border-gray-700/50 backdrop-blur-sm hover:bg-white/95 dark:hover:bg-gray-800/95 transition-colors"
           >
             {product.category}
           </Badge>
@@ -45,9 +45,9 @@ const ProductCard = ({ product }: ProductCardProps) => {
               {formatPriceBRL(product.price)}
             </span>
             {product.rating && (
-              <div className="flex items-center gap-1 bg-accent/10 px-2 py-1 rounded-full">
+              <div className="flex items-center gap-1 bg-accent/10 dark:bg-accent/20 px-2 py-1 rounded-full">
                 <Star className="w-4 h-4 fill-accent text-accent" />
-                <span className="text-sm font-medium text-accent-foreground">{product.rating}</span>
+                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{product.rating}</span>
               </div>
             )}
           </div>


### PR DESCRIPTION
Fix badge colors on product cards to improve readability and contrast in dark mode.

The previous `text-accent-foreground` and `bg-background/90 text-foreground` styles resulted in poor contrast for "Novo", category, and rating badges when viewed in dark mode. This PR introduces specific `dark:` utility classes to ensure appropriate text and background colors for better legibility in both light and dark themes.

---
<a href="https://cursor.com/background-agent?bcId=bc-004da956-b292-43cc-a0c1-5a3456b85b39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-004da956-b292-43cc-a0c1-5a3456b85b39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

