### PR TITLE
Fix all filter disappearing after google sheets load

### DIFF
--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -13,7 +13,9 @@ export const useProducts = () => {
       if (!isMounted) return;
       if (Array.isArray(list) && list.length > 0) {
         setAllProducts(list as Product[]);
-        setCategories(Array.from(new Set(list.map((i) => i.category))));
+        // Sempre incluir "todos" como primeira opção, seguido pelas categorias únicas dos produtos
+        const uniqueCategories = Array.from(new Set(list.map((i) => i.category).filter(Boolean)));
+        setCategories(["todos", ...uniqueCategories]);
       }
     });
     return () => {
@@ -26,9 +28,9 @@ export const useProducts = () => {
       return allProducts;
     }
 
-    const categoryName = categories.find((it) => it === selectedCategory);
+    const categoryName = categories.find((it: string) => it === selectedCategory);
 
-    return allProducts.filter((product) => product.category === categoryName);
+    return allProducts.filter((product: Product) => product.category === categoryName);
   }, [selectedCategory, allProducts, categories]);
 
   return {


### PR DESCRIPTION
Adiciona a opção 'todos' às categorias de produtos e filtra categorias vazias para garantir que o filtro 'todos' esteja sempre disponível.

O problema ocorria porque, ao carregar os produtos do Google Sheets, o array de categorias era completamente sobrescrito apenas com as categorias encontradas nos produtos, fazendo com que a opção 'todos' desaparecesse. Esta alteração garante que 'todos' seja sempre incluído como a primeira opção.

---
<a href="https://cursor.com/background-agent?bcId=bc-10ccc973-b2f1-4cc4-b6ad-983a6a1c0fbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10ccc973-b2f1-4cc4-b6ad-983a6a1c0fbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

