### PR TITLE
Fix all filter disappearing after google sheets load

### DIFF
--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -13,7 +13,18 @@ export const useProducts = () => {
       if (!isMounted) return;
       if (Array.isArray(list) && list.length > 0) {
         setAllProducts(list as Product[]);
-        setCategories(Array.from(new Set(list.map((i) => i.category))));
+        const uniqueCategories = Array.from(
+          new Set(
+            list
+              .map((item) => String(item.category || '').trim())
+              .filter((name) => name.length > 0)
+          )
+        );
+        const withoutTodos = uniqueCategories.filter(
+          (name) => name.toLowerCase() !== "todos"
+        );
+        withoutTodos.sort((a, b) => a.localeCompare(b));
+        setCategories(["todos", ...withoutTodos]);
       }
     });
     return () => {
@@ -26,9 +37,9 @@ export const useProducts = () => {
       return allProducts;
     }
 
-    const categoryName = categories.find((it) => it === selectedCategory);
+    const categoryName = categories.find((it: string) => it === selectedCategory);
 
-    return allProducts.filter((product) => product.category === categoryName);
+    return allProducts.filter((product: Product) => product.category === categoryName);
   }, [selectedCategory, allProducts, categories]);
 
   return {


### PR DESCRIPTION
Ensure "todos" category is always available and correctly filters products.

The "todos" option for product categories was disappearing after products were loaded from Google Sheets, preventing users from clearing the product filter. This change ensures "todos" is always prepended to the category list and correctly filters all products.

---
<a href="https://cursor.com/background-agent?bcId=bc-783247f1-a183-46dc-8d9a-8781623aaddd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-783247f1-a183-46dc-8d9a-8781623aaddd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

