### PR TITLE
Fix tanstack head tag injection

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,105 +1,80 @@
 import { createRootRoute, Outlet } from "@tanstack/react-router";
 import { Providers } from "@/components/Providers";
+import { useEffect } from "react";
 
 const title = "SeRena Cosméticos";
 const description = "Distribuidora de comésticos do ABC paulista";
 const url = window.location.origin;
 
 export const Route = createRootRoute({
-  head: () => ({
-    meta: [
-      {
-        title,
-      },
-      {
-        name: "description",
-        content: description,
-      },
-      {
-        name: "viewport",
-        content: "width=device-width, initial-scale=1.0",
-      },
-      {
-        name: "application-name",
-        content: title,
-      },
-      {
-        name: "apple-mobile-web-app-capable",
-        content: "yes",
-      },
-      {
-        name: "apple-mobile-web-app-status-bar-style",
-        content: "default",
-      },
-      {
-        name: "apple-mobile-web-app-title",
-        content: title,
-      },
-      {
-        name: "format-detection",
-        content: "telephone=no",
-      },
-      {
-        name: "mobile-web-app-capable",
-        content: "yes",
-      },
-      {
-        name: "theme-color",
-        content: "oklch(0.21 0.006 285.885)", // Uses primary color from theme
-      },
-      {
-        name: "og:type",
-        content: "website",
-      },
-      {
-        name: "og:url",
-        content: url,
-      },
-      {
-        name: "og:title",
-        content: title,
-      },
-      {
-        name: "og:description",
-        content: description,
-      },
-      {
-        name: "twitter:card",
-        content: "summary_large_image",
-      },
-      {
-        name: "twitter:url",
-        content: url,
-      },
-      {
-        name: "twitter:title",
-        content: title,
-      },
-      {
-        name: "twitter:description",
-        content: description,
-      },
-    ],
-    links: [
-      {
-        rel: "icon",
-        href: "/favicon.ico",
-      },
-      {
-        rel: "apple-touch-icon",
-        href: "/apple-touch-icon-180x180.png",
-      },
-      {
-        rel: "manifest",
-        href: "/manifest.webmanifest",
-      },
-    ],
-  }),
-  component: () => (
-    <>
-      <Providers>
-        <Outlet />
-      </Providers>
-    </>
-  ),
+  component: () => {
+    useEffect(() => {
+      // Set document title
+      document.title = title;
+      
+      // Set meta tags
+      const setMetaTag = (name: string, content: string, isProperty?: boolean) => {
+        const selector = isProperty ? `meta[property="${name}"]` : `meta[name="${name}"]`;
+        let meta = document.querySelector(selector) as HTMLMetaElement;
+        
+        if (!meta) {
+          meta = document.createElement('meta');
+          if (isProperty) {
+            meta.setAttribute('property', name);
+          } else {
+            meta.setAttribute('name', name);
+          }
+          document.head.appendChild(meta);
+        }
+        meta.setAttribute('content', content);
+      };
+
+      // Set all meta tags
+      setMetaTag('description', description);
+      setMetaTag('viewport', 'width=device-width, initial-scale=1.0');
+      setMetaTag('application-name', title);
+      setMetaTag('apple-mobile-web-app-capable', 'yes');
+      setMetaTag('apple-mobile-web-app-status-bar-style', 'default');
+      setMetaTag('apple-mobile-web-app-title', title);
+      setMetaTag('format-detection', 'telephone=no');
+      setMetaTag('mobile-web-app-capable', 'yes');
+      setMetaTag('theme-color', 'oklch(0.21 0.006 285.885)');
+      
+      // Open Graph tags
+      setMetaTag('og:type', 'website', true);
+      setMetaTag('og:url', url, true);
+      setMetaTag('og:title', title, true);
+      setMetaTag('og:description', description, true);
+      
+      // Twitter tags
+      setMetaTag('twitter:card', 'summary_large_image');
+      setMetaTag('twitter:url', url);
+      setMetaTag('twitter:title', title);
+      setMetaTag('twitter:description', description);
+
+      // Set favicon and other links
+      const setLinkTag = (rel: string, href: string) => {
+        let link = document.querySelector(`link[rel="${rel}"]`) as HTMLLinkElement;
+        
+        if (!link) {
+          link = document.createElement('link');
+          link.setAttribute('rel', rel);
+          document.head.appendChild(link);
+        }
+        link.setAttribute('href', href);
+      };
+
+      setLinkTag('icon', '/favicon.ico');
+      setLinkTag('apple-touch-icon', '/apple-touch-icon-180x180.png');
+      setLinkTag('manifest', '/manifest.webmanifest');
+    }, []);
+
+    return (
+      <>
+        <Providers>
+          <Outlet />
+        </Providers>
+      </>
+    );
+  },
 });


### PR DESCRIPTION
Dynamically inject head tags using `useEffect` in `__root.tsx` to ensure proper rendering in client-side TanStack Router applications.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae609a0c-bc64-4db1-a2bc-11587c8680e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae609a0c-bc64-4db1-a2bc-11587c8680e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

