### PR TITLE
Fix tanstack head tag injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
-  <head></head>
+  <head>
+    <title>SeRena Cosméticos</title>
+  </head>
 
   <body>
     <div id="app"></div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Outlet, HeadContent } from "@tanstack/react-router";
 import { Providers } from "@/components/Providers";
 
 const title = "SeRena Cosméticos";
@@ -97,6 +97,7 @@ export const Route = createRootRoute({
   }),
   component: () => (
     <>
+      <HeadContent />
       <Providers>
         <Outlet />
       </Providers>


### PR DESCRIPTION
Enable TanStack Router's head tag injection by adding the `HeadContent` component and a fallback title.

---
<a href="https://cursor.com/background-agent?bcId=bc-fce9b6b9-3d6d-4651-bb1f-aa53e4f89b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fce9b6b9-3d6d-4651-bb1f-aa53e4f89b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

