### PR TITLE
Fix tanstack head tag injection

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,9 +1,9 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Outlet, HeadContent } from "@tanstack/react-router";
 import { Providers } from "@/components/Providers";
 
 const title = "SeRena Cosméticos";
 const description = "Distribuidora de comésticos do ABC paulista";
-const url = window.location.origin;
+const url = typeof window !== "undefined" ? window.location.origin : "";
 
 export const Route = createRootRoute({
   head: () => ({
@@ -97,6 +97,7 @@ export const Route = createRootRoute({
   }),
   component: () => (
     <>
+      <HeadContent />
       <Providers>
         <Outlet />
       </Providers>


### PR DESCRIPTION
Add `HeadContent` component and make `window.location.origin` SSR-safe to enable TanStack Router to correctly inject head tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-e886a40b-c7fa-4151-a431-9c915e9a8e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e886a40b-c7fa-4151-a431-9c915e9a8e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

