### PR TITLE
Add address to homepage

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -105,9 +105,13 @@ const Contact = ({ sectionId }: { sectionId: string }) => {
                   <div>
                     <h3 className="font-semibold text-lg mb-2">Localização</h3>
                     <p className="text-muted-foreground">
-                      São Paulo, SP - Brasil
+                      Av. Sorocaba, 961, Pq João Ramalho
                       <br />
-                      Atendimento presencial sob agendamento
+                      Santo André - SP
+                      <br />
+                      <span className="text-sm opacity-75">
+                        Atendimento presencial sob agendamento
+                      </span>
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
Add the specific address "Av. Sorocaba, 961, Pq João Ramalho, Santo André - SP" to the contact section on the home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3468e19-4838-4f3e-a712-9439a94355eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3468e19-4838-4f3e-a712-9439a94355eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

