### PR TITLE
Fix missing hero component

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 import heroImage from "@/assets/logo.png";
 import { Button } from "@/components/ui/button";
 import { WhatsAppButton } from "./ui/whatsapp-button";
+import { Link } from "@tanstack/react-router";
 
 const Hero = ({ sectionId }: { sectionId: string }) => {
   return (


### PR DESCRIPTION
Add missing `Link` import to Hero component because it was used without being imported.

---
<a href="https://cursor.com/background-agent?bcId=bc-304cfaf7-e376-4163-afcb-a64275e9da70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-304cfaf7-e376-4163-afcb-a64275e9da70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

