### PR TITLE
Fix dark mode theme provider

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -5,7 +5,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { ThemeProvider } from "next-themes";
+import { ThemeProvider } from "@/components/theme-provider";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { createQueryClient } from "@/lib/queryClient";
 import { CartProvider } from "@/contexts/CartContext";


### PR DESCRIPTION
Use custom `ThemeProvider` in `Providers.tsx` to enable dark mode functionality.

The previous import directly used `ThemeProvider` from `next-themes`, bypassing the custom `ThemeProvider` component which includes critical configurations like `attribute="class"`, `defaultTheme="system"`, `enableSystem`, and `disableTransitionOnChange`. These settings are essential for the dark mode styles to be applied correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-c42381b5-77c2-4b04-9012-8ff58d21bc98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c42381b5-77c2-4b04-9012-8ff58d21bc98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

