### PR TITLE
Adjust product detail images to match card styling

### DIFF
--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -48,7 +48,7 @@ export function ImageGallery({ images, productName }: ImageGalleryProps) {
             <img
               src={images[currentIndex]}
               alt={`${productName} - Imagem ${currentIndex + 1}`}
-              className="w-full h-96 object-cover rounded-lg cursor-pointer transition-transform hover:scale-105"
+              className="w-full h-96 object-scale-down rounded-lg cursor-pointer transition-transform hover:scale-105"
               onClick={openFullscreen}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -112,7 +112,7 @@ export function ImageGallery({ images, productName }: ImageGalleryProps) {
                 <img
                   src={image}
                   alt={`Thumbnail ${index + 1}`}
-                  className="w-full h-full object-cover"
+                  className="w-full h-full object-scale-down"
                   onError={(e) => {
                     const target = e.target as HTMLImageElement;
                     target.src = "/placeholder.svg";
@@ -187,7 +187,7 @@ export function ImageGallery({ images, productName }: ImageGalleryProps) {
                     <img
                       src={image}
                       alt={`Thumbnail ${index + 1}`}
-                      className="w-full h-full object-cover"
+                      className="w-full h-full object-scale-down"
                       onError={(e) => {
                         const target = e.target as HTMLImageElement;
                         target.src = "/placeholder.svg";


### PR DESCRIPTION
Corrige o overflow de imagens na página de detalhes do produto, alterando `object-cover` para `object-scale-down` para padronizar com os cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-db273f90-f2c1-4edf-a817-295cf11604b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db273f90-f2c1-4edf-a817-295cf11604b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

